### PR TITLE
Change renderer to gles2

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -25,4 +25,7 @@ Network="*res://network.gd"
 
 [rendering]
 
+quality/driver/driver_name="GLES2"
+vram_compression/import_etc=true
+vram_compression/import_etc2=false
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
No need to use GLES3 Renderer in this type of project. However, it's have a harm, cuz some users with old video cards can't run the project and even sometimes can get a blue screen.